### PR TITLE
Add guest login endpoint and anonymous access

### DIFF
--- a/backend/src/main/java/com/zusa/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/zusa/backend/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.http.HttpMethod;
 
 /**
  * SecurityConfig – 最终版
@@ -59,8 +60,9 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(ex -> ex.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .authorizeHttpRequests(auth -> auth
-                        // 登录 / 注册接口公开
-                        .requestMatchers("/api/auth/**").permitAll()
+                        // 登录接口公开
+                        .requestMatchers("/api/auth/login", "/api/auth/register", "/api/auth/refresh").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/auth/guest", "/api/auth/mp/login").permitAll()
                         // 静态资源 & 头像接口全部公开
                         .requestMatchers(
                                 "/static/**",
@@ -68,6 +70,8 @@ public class SecurityConfig {
                                 "/api/media/photo/**",
                                 "/api/media/profile/**"
                         ).permitAll()
+                        // 匿名 GET 访问
+                        .requestMatchers(HttpMethod.GET, "/api/posts/**", "/api/users/**").permitAll()
                         // 其它请求需 JWT
                         .anyRequest().authenticated())
                 .authenticationProvider(authProvider)

--- a/backend/src/main/java/com/zusa/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/zusa/backend/controller/AuthController.java
@@ -3,9 +3,12 @@ package com.zusa.backend.controller;
 import com.zusa.backend.dto.auth.JwtResponse;
 import com.zusa.backend.dto.auth.RefreshTokenRequest;
 import com.zusa.backend.dto.auth.TokenClaims;
+import com.zusa.backend.dto.auth.GuestJwtResponse;
 import com.zusa.backend.dto.user.UserDto;
+import com.zusa.backend.dto.user.UserReadDto;
 import com.zusa.backend.security.JwtUtils;
 import com.zusa.backend.service.UserService;
+import com.zusa.backend.service.mapper.UserMapper;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +35,7 @@ public class AuthController {
     private final UserService userService;
     private final AuthenticationManager authenticationManager;
     private final JwtUtils jwtUtils;
+    private final UserMapper userMapper;
 
     /**
      * 注册请求参数
@@ -119,6 +123,32 @@ public class AuthController {
                 .build();
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 游客登录，生成临时账号
+     */
+    @PostMapping("/guest")
+    public ResponseEntity<GuestJwtResponse> guestLogin() {
+        log.info("[👤 /guest] 游客登录请求");
+
+        UserDto dto = userService.createGuestUser();
+
+        TokenClaims claims = new TokenClaims();
+        claims.setUserUuid(dto.getUuid());
+        claims.setEmail(dto.getEmail());
+        String accessToken = jwtUtils.generateAccessToken(claims);
+        String refreshToken = jwtUtils.generateRefreshToken(dto.getUuid());
+
+        UserReadDto readDto = userMapper.toReadDto(dto);
+
+        GuestJwtResponse resp = GuestJwtResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .user(readDto)
+                .build();
+
+        return ResponseEntity.ok(resp);
     }
 
     /**

--- a/backend/src/main/java/com/zusa/backend/dto/auth/GuestJwtResponse.java
+++ b/backend/src/main/java/com/zusa/backend/dto/auth/GuestJwtResponse.java
@@ -1,0 +1,19 @@
+package com.zusa.backend.dto.auth;
+
+import com.zusa.backend.dto.user.UserReadDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GuestJwtResponse {
+    private String accessToken;
+    private String refreshToken;
+    @Builder.Default
+    private String tokenType = "Bearer";
+    private UserReadDto user;
+}

--- a/backend/src/main/java/com/zusa/backend/dto/user/UserReadDto.java
+++ b/backend/src/main/java/com/zusa/backend/dto/user/UserReadDto.java
@@ -1,0 +1,13 @@
+package com.zusa.backend.dto.user;
+
+import lombok.Data;
+import java.util.UUID;
+
+@Data
+public class UserReadDto {
+    private UUID uuid;
+    private Long shortId;
+    private String nickname;
+    private String avatarUrl;
+    private String bio;
+}

--- a/backend/src/main/java/com/zusa/backend/entity/Role.java
+++ b/backend/src/main/java/com/zusa/backend/entity/Role.java
@@ -1,0 +1,6 @@
+package com.zusa.backend.entity;
+
+public enum Role {
+    USER,
+    GUEST
+}

--- a/backend/src/main/java/com/zusa/backend/entity/User.java
+++ b/backend/src/main/java/com/zusa/backend/entity/User.java
@@ -2,6 +2,7 @@
 package com.zusa.backend.entity;
 
 import com.zusa.backend.entity.user.*;
+import com.zusa.backend.entity.Role;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
@@ -36,6 +37,12 @@ public class User {
     @JdbcTypeCode(SqlTypes.BINARY)
     @Column(name = "uuid", columnDefinition = "BINARY(16)", nullable = false, updatable = false, unique = true)
     private UUID uuid = UUID.randomUUID();
+
+    /** 用户角色 */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private Role role = Role.USER;
 
 
     /** 登录邮箱 */

--- a/backend/src/main/java/com/zusa/backend/service/AuthService.java
+++ b/backend/src/main/java/com/zusa/backend/service/AuthService.java
@@ -96,7 +96,7 @@ public class AuthService implements UserDetailsService {
         return org.springframework.security.core.userdetails.User
                 .withUsername(u.getUuid().toString()) // username 设置为 UUID
                 .password(u.getPassword())
-                .roles("USER")
+                .roles(u.getRole().name())
                 .build();
     }
 

--- a/backend/src/main/java/com/zusa/backend/service/UserService.java
+++ b/backend/src/main/java/com/zusa/backend/service/UserService.java
@@ -14,6 +14,9 @@ public interface UserService {
     UserDto register(String email, String rawPassword, String nickname);
     UserDto login(String username, String password);
 
+    // 游客登录
+    UserDto createGuestUser();
+
     // UUID 资料查询
     UserDto getUserProfileByUuid(UUID uuid);
 

--- a/backend/src/main/java/com/zusa/backend/service/impl/UserServiceImpl.java
+++ b/backend/src/main/java/com/zusa/backend/service/impl/UserServiceImpl.java
@@ -71,6 +71,24 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
+    @Transactional
+    public UserDto createGuestUser() {
+        long shortId = generateUniqueShortId();
+        String nickname = "Guest" + System.currentTimeMillis();
+        String email = "guest-" + UUID.randomUUID() + "@guest.local";
+        User u = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(UUID.randomUUID().toString()))
+                .nickname(nickname)
+                .shortId(shortId)
+                .role(com.zusa.backend.entity.Role.GUEST)
+                .build();
+
+        userRepo.save(u);
+        return userMapper.toDto(u);
+    }
+
+    @Override
     @Transactional(readOnly = true)
     public UserDto login(String username, String rawPassword) {
         Optional<User> opt = username.contains("@")

--- a/backend/src/main/java/com/zusa/backend/service/mapper/UserMapper.java
+++ b/backend/src/main/java/com/zusa/backend/service/mapper/UserMapper.java
@@ -62,4 +62,13 @@ public interface UserMapper {
     @Mapping(target = "profilePictureUrl",
             expression = "java(user.getProfilePicture() != null ? \"/api/media/profile/\" + user.getProfilePicture().getUuid() : null)")
     UserSummaryDto toSummaryDto(User user);
+
+    /** Guest/Read mapping User → UserReadDto */
+    @Mapping(target = "avatarUrl",
+            expression = "java(user.getProfilePicture() != null ? \"/api/media/profile/\" + user.getProfilePicture().getUuid() : null)")
+    UserReadDto toReadDto(User user);
+
+    /** Mapping from UserDto to UserReadDto */
+    @Mapping(target = "avatarUrl", source = "profilePictureUrl")
+    UserReadDto toReadDto(UserDto dto);
 }


### PR DESCRIPTION
## Summary
- implement guest login endpoint with `UserMapper` mapping
- allow `/api/auth/guest` and `GET /api/posts/**` anonymous access
- include role field on `User` and support guest role
- update `SecurityConfig` for anonymous endpoints

## Testing
- `./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6881a91ef1e0832e81bfaa1c10329595