### PR TITLE
Add grid feed page in wxapp

### DIFF
--- a/wxapp/app.json
+++ b/wxapp/app.json
@@ -2,6 +2,7 @@
   "pages": [
     "pages/chat/index/index",
     "pages/square/index/index",
+    "pages/square/feed/index",
     "pages/game/index/index",
     "pages/me/index/index",
     "pages/square/postDetail/index"

--- a/wxapp/pages/square/feed/index.js
+++ b/wxapp/pages/square/feed/index.js
@@ -1,0 +1,11 @@
+const posts = require('../../../utils/mockPosts');
+
+Page({
+  data: {
+    posts: []
+  },
+
+  onLoad() {
+    this.setData({ posts });
+  }
+});

--- a/wxapp/pages/square/feed/index.json
+++ b/wxapp/pages/square/feed/index.json
@@ -1,0 +1,4 @@
+{
+  "navigationBarTitleText": "广场",
+  "enablePullDownRefresh": true
+}

--- a/wxapp/pages/square/feed/index.wxml
+++ b/wxapp/pages/square/feed/index.wxml
@@ -1,0 +1,14 @@
+<scroll-view class="container" scroll-y="true">
+  <view class="grid">
+    <block wx:for="{{posts}}" wx:key="id">
+      <view class="card">
+        <image class="card-image" mode="aspectFill" src="{{item.coverUrl}}" />
+        <text class="card-title">{{item.title}}</text>
+        <view class="card-footer">
+          <text class="author">{{item.authorName}}</text>
+          <text class="likes">❤ {{item.likeCount}}</text>
+        </view>
+      </view>
+    </block>
+  </view>
+</scroll-view>

--- a/wxapp/pages/square/feed/index.wxss
+++ b/wxapp/pages/square/feed/index.wxss
@@ -1,0 +1,55 @@
+.container {
+  height: 100vh;
+  background: #fff;
+}
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  padding: 8rpx;
+  box-sizing: border-box;
+}
+
+.card {
+  width: 48%;
+  margin-bottom: 16rpx;
+  background: #fff;
+  border-radius: 8rpx;
+  overflow: hidden;
+  box-shadow: 0 4rpx 8rpx rgba(0, 0, 0, 0.05);
+}
+
+.card:nth-child(2n + 1) {
+  margin-right: 4%;
+}
+
+.card-image {
+  width: 100%;
+  height: 260rpx;
+}
+
+.card-title {
+  display: block;
+  padding: 8rpx;
+  font-size: 28rpx;
+  line-height: 36rpx;
+  color: #222;
+}
+
+.card-footer {
+  padding: 0 8rpx 8rpx;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.author {
+  font-size: 24rpx;
+  color: #666;
+}
+
+.likes {
+  font-size: 24rpx;
+  color: #666;
+}

--- a/wxapp/utils/mockPosts.js
+++ b/wxapp/utils/mockPosts.js
@@ -1,0 +1,58 @@
+module.exports = [
+  {
+    id: 1,
+    coverUrl: 'https://via.placeholder.com/400x520',
+    title: '示例贴子标题一',
+    authorName: '作者A',
+    likeCount: 23
+  },
+  {
+    id: 2,
+    coverUrl: 'https://via.placeholder.com/400x500',
+    title: '示例贴子标题二',
+    authorName: '作者B',
+    likeCount: 45
+  },
+  {
+    id: 3,
+    coverUrl: 'https://via.placeholder.com/400x540',
+    title: '示例贴子标题三',
+    authorName: '作者C',
+    likeCount: 12
+  },
+  {
+    id: 4,
+    coverUrl: 'https://via.placeholder.com/400x510',
+    title: '示例贴子标题四',
+    authorName: '作者D',
+    likeCount: 67
+  },
+  {
+    id: 5,
+    coverUrl: 'https://via.placeholder.com/400x525',
+    title: '示例贴子标题五',
+    authorName: '作者E',
+    likeCount: 5
+  },
+  {
+    id: 6,
+    coverUrl: 'https://via.placeholder.com/400x515',
+    title: '示例贴子标题六',
+    authorName: '作者F',
+    likeCount: 39
+  },
+  {
+    id: 7,
+    coverUrl: 'https://via.placeholder.com/400x535',
+    title: '示例贴子标题七',
+    authorName: '作者G',
+    likeCount: 16
+  },
+  {
+    id: 8,
+    coverUrl: 'https://via.placeholder.com/400x530',
+    title: '示例贴子标题八',
+    authorName: '作者H',
+    likeCount: 82
+  }
+];


### PR DESCRIPTION
## Summary
- move square feed implementation into existing `wxapp` project
- register new `pages/square/feed/index` page in app configuration
- provide mock data and page UI for a two-column grid layout
- remove the previously created `miniprogram` folder

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6885646197dc832e92767f8fcf2854f3